### PR TITLE
Add support for routed IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ check "allocated-cpu" {
 - `commercial_type` `(string: "")` - A Scaleway server instance commercial type. Refer to the [Scaleway Pricing](https://www.scaleway.com/en/pricing/?tags=compute) page for a list of available types.
 - `image` `(string: "")` - The Scaleway image ID.
 - `enable_ipv6` `(string: "false")` - A boolean in string format. If set to `"true"`, sets an IPv6 IP address after instance creation.
+- `routed_ip` `(string: "false")` - A boolean in string format. If set to `"true"`, enables routed IP mode for this instance.
 - `security_group` `(string: "")` - The Scaleawy server instance security group ID.
 - `placement_group` `(string: "")` - The Scaleway server instance placement group ID.
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/nomad-autoscaler v0.3.7
 	github.com/hashicorp/nomad/api v0.0.0-20220519231241-2b054e38e91a
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.13
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.26
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -192,10 +192,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.11 h1:aBAUkfUmdpAs/7Yeq6T3inWFaKPxDmdkLMjbktx7qCs=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.11/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.13 h1:n5J2K6g/kl/iT6mODjCoSoRBGQVmIG3aMtYbofi9kxc=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.13/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.26 h1:F+GIVtGqCFxPxO46ujf8cEOP574MBoRm3gNbPXECbxs=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.26/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/scaleway/instance/instance_test.go
+++ b/scaleway/instance/instance_test.go
@@ -30,7 +30,7 @@ func NewTestClient(t *testing.T) (*scw.Client, error) {
 // NewTestServer returns a new test server instance
 func NewTestServer() (server Server, err error) {
 	return server, server.Decode(map[string]string{
-		"image":           "0d1cf4a3-aae9-4294-9fd9-fefffb297615",
+		"image":           "ubuntu_focal",
 		"commercial_type": "DEV1-S",
 		"dynamic_ip":      "true",
 		"enable_ipv6":     "true",

--- a/scaleway/instance/server.go
+++ b/scaleway/instance/server.go
@@ -20,6 +20,7 @@ func (s *Server) Decode(config map[string]string) error {
 		Tags           types.SliceString `mapstructure:"tags"`
 		Zone           string            `mapstructure:"zone"`
 		DynamicIP      types.Bool        `mapstructure:"dynamic_ip"`
+		RoutedIP       types.Bool        `mapstructure:"routed_ip"`
 		CommercialType string            `mapstructure:"commercial_type"`
 		Image          *string           `mapstructure:"image"`
 		EnableIPv6     types.Bool        `mapstructure:"enable_ipv6"`
@@ -48,6 +49,7 @@ func (s *Server) Decode(config map[string]string) error {
 		Name:              shadow.Name,
 		Zone:              zone,
 		DynamicIPRequired: bool(shadow.DynamicIP),
+		RoutedIPEnabled:   bool(shadow.RoutedIP),
 		CommercialType:    shadow.CommercialType,
 		Tags:              append([]string{"nomad", "client", "autoscaler"}, shadow.Tags...),
 		EnableIPv6:        bool(shadow.EnableIPv6),
@@ -77,6 +79,7 @@ func (s *Server) CreateServerRequest() *instance.CreateServerRequest {
 		Zone:              s.Zone,
 		Name:              s.Name,
 		DynamicIPRequired: &s.DynamicIPRequired,
+		RoutedIPEnabled:   &s.RoutedIPEnabled,
 		CommercialType:    s.CommercialType,
 		Volumes:           map[string]*instance.VolumeServerTemplate{},
 		EnableIPv6:        s.EnableIPv6,


### PR DESCRIPTION
Scaleway recently added support for routed IPs. This PR makes it configurable in the target plugin.